### PR TITLE
Set empty string as error field name

### DIFF
--- a/Importer/Interpreter/EntityDataInterpreter.php
+++ b/Importer/Interpreter/EntityDataInterpreter.php
@@ -341,6 +341,6 @@ class EntityDataInterpreter implements InterpreterInterface
             }
         }
 
-        throw new \Exception('Field for property path “' . $propertyPath . '” was not found');
+        return '';
     }
 }


### PR DESCRIPTION
We should set empty string as field name of error, when validation error's property path does not match any field of the configuration file